### PR TITLE
Fix bug: Remove SplashActivity history

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.movie.it">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -17,7 +19,8 @@
         <activity android:name=".LoginActivity" />
         <activity
             android:name=".SplashActivity"
-            android:label="@string/title_activity_splash">
+            android:label="@string/title_activity_splash"
+            android:noHistory="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/movie/it/MovieAdapter.kt
+++ b/app/src/main/java/com/movie/it/MovieAdapter.kt
@@ -1,0 +1,4 @@
+package com.movie.it
+
+class MovieAdapter {
+}


### PR DESCRIPTION
[버그픽스]: 취소버튼으로 앱 종료가 안됨
스플래시 액티비티 히스토리를 지웠습니다. 